### PR TITLE
docs(env): clarify acme DEFAULT_EMAIL vs per-container LETSENCRYPT_EMAIL

### DIFF
--- a/mosquitto/.env.template
+++ b/mosquitto/.env.template
@@ -12,5 +12,8 @@
 # Default (dedicated MQTT host, root path):
 VIRTUAL_HOST_MULTIPORTS={"mqtt.sd40.lan":{"/":{"port":9001,"proto":"http","dest":""}}}
 
+# TLS with userver-web acme-companion: set DEFAULT_EMAIL once in letsencrypt/.env; avoid repeating
+# LETSENCRYPT_EMAIL on every backend (addresses get concatenated and ACME fails).
+
 # Optional: long-lived idle MQTT over WebSocket may need higher proxy_read_timeout on nginx-proxy (e.g. add
 # directives under /etc/nginx/vhost.d/<VIRTUAL_HOST>_location or the path-hash location file for this service).

--- a/rabbitmq/.env.template
+++ b/rabbitmq/.env.template
@@ -8,6 +8,9 @@
 # Default:
 VIRTUAL_HOST_MULTIPORTS={"rabbitmq.sd40.lan":{"/":{"port":15672,"proto":"http","dest":""}}}
 
+# TLS with userver-web acme-companion: set DEFAULT_EMAIL once in letsencrypt/.env; avoid repeating the
+# same LETSENCRYPT_EMAIL on every backend (acme-companion concatenates them and breaks registration).
+
 # This environment variable is used to set the deployment ID for the RabbitMQ server.
 DEPLOYMENT_ID=sd40-2
 


### PR DESCRIPTION
Document that repeating the same email on many containers breaks ACME when using userver-web nginx-proxy / acme-companion (addresses get concatenated).

Made-with: Cursor

## Summary

<!-- Brief description of the change (compose, Mosquitto, RabbitMQ, CI, docs, etc.). -->

## Checklist

- [ ] `docker compose config` is valid and services start locally (`docker compose up --build`)
- [ ] Any new or changed shell scripts pass ShellCheck (see Codebase Quality workflow)
- [ ] Secrets stay out of committed `.env` files (use `.env.template` only in git)

Thanks!
