### PR TITLE
fix: wss certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Both services attach to the external network **`nginx-proxy`** so the proxy can 
 
 `VIRTUAL_HOST_MULTIPORTS` should only list **HTTP** upstreams for nginx-proxy. The template maps the **management plugin (15672)**; **5672 is not proxied** through nginx-proxy’s HTTP layer.
 
+**Production `wss://`:** The hostname in **`VIRTUAL_HOST_MULTIPORTS`** must be the same FQDN clients use (DNS + TLS SAN). Set **`LETSENCRYPT_HOST`** to that name for **acme-companion** (the **userver** deploy script sets it from **`USERVER_EVENTMGR_MQTT_HOSTNAME`.`USERVER_VIRTUAL_HOST`** or from **`USERVER_EVENTMGR_MQTT_WSS_HOST`** when defined). If that hostname is missing or nginx falls through to another app (Adminer, etc.), TLS may succeed but WebSocket upgrades will fail.
+
 ---
 
 ## Prerequisites

--- a/mosquitto/.env.template
+++ b/mosquitto/.env.template
@@ -9,11 +9,17 @@
 # broker still sees requests at its WebSocket root, for example:
 #   VIRTUAL_HOST_MULTIPORTS={"mqtt.example.com":{"/mqtt":{"port":9001,"proto":"http","dest":"/"}}}
 #
-# Default (dedicated MQTT host, root path):
+# Default (dedicated MQTT host, root path). The JSON key must match DNS and the certificate SAN.
 VIRTUAL_HOST_MULTIPORTS={"mqtt.sd40.lan":{"/":{"port":9001,"proto":"http","dest":""}}}
+
+# nginx-proxy / acme-companion: same FQDN as the key in VIRTUAL_HOST_MULTIPORTS (comma-separated if several).
+# userver deploy_userver_eventmgr.sh overwrites this from ${USERVER_EVENTMGR_MQTT_HOSTNAME}.${USERVER_VIRTUAL_HOST}
+# or from USERVER_EVENTMGR_MQTT_WSS_HOST when that variable is set (public MQTT name vs internal apex domain).
+LETSENCRYPT_HOST=
 
 # TLS with userver-web acme-companion: set DEFAULT_EMAIL once in letsencrypt/.env; avoid repeating
 # LETSENCRYPT_EMAIL on every backend (addresses get concatenated and ACME fails).
+LETSENCRYPT_EMAIL=
 
 # Optional: long-lived idle MQTT over WebSocket may need higher proxy_read_timeout on nginx-proxy (e.g. add
 # directives under /etc/nginx/vhost.d/<VIRTUAL_HOST>_location or the path-hash location file for this service).


### PR DESCRIPTION
## Summary

<!-- Brief description of the change (compose, Mosquitto, RabbitMQ, CI, docs, etc.). -->

## Checklist

- [ ] `docker compose config` is valid and services start locally (`docker compose up --build`)
- [ ] Any new or changed shell scripts pass ShellCheck (see Codebase Quality workflow)
- [ ] Secrets stay out of committed `.env` files (use `.env.template` only in git)

Thanks!
